### PR TITLE
Improve performance of check-case-conflict

### DIFF
--- a/test/Hooky/__snapshots__/LintSpec.snap.md
+++ b/test/Hooky/__snapshots__/LintSpec.snap.md
@@ -10,9 +10,6 @@ foo-link.txt:
 ## check_case_conflict / fails when files conflict
 
 ```
-FOO.TXT:
-- [check_case_conflict] File conflicts with: foo.txt
-
 foo.txt:
 - [check_case_conflict] File conflicts with: FOO.TXT
 ```


### PR DESCRIPTION
The previous implementation of `check-case-conflict` was `O(n^2)`. The new algorithm is `O(n log n)`