### PR TITLE
Filter out deleted files

### DIFF
--- a/src/Hooky/Utils/Git.hs
+++ b/src/Hooky/Utils/Git.hs
@@ -8,6 +8,7 @@ module Hooky.Utils.Git (
 ) where
 
 import Control.Monad (void)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as Text
 import GHC.Records (HasField (..))
@@ -47,6 +48,12 @@ instance HasField "getFilesWith" GitClient ([String] -> IO [FilePath]) where
    where
     split = map Text.unpack . filter (not . Text.null) . Text.splitOn (Text.pack "\0")
 instance HasField "getFiles" GitClient (IO [FilePath]) where
-  getField git = git.getFilesWith ["ls-files"]
+  getField git = do
+    files <- git.getFilesWith ["ls-files"]
+    deletedFiles <- git.getFilesWith ["ls-files", "--deleted"]
+    pure $ files `without` deletedFiles
+   where
+    -- 'y' is usually small, so this should be O(n) in the common case.
+    x `without` y = filter (`Set.notMember` Set.fromList y) x
 instance HasField "getChangedFiles" GitClient ([String] -> IO [FilePath]) where
   getField git args = git.getFilesWith $ ["diff", "--name-only", "--diff-filter=AMR"] <> args

--- a/test/Hooky/E2ESpec.hs
+++ b/test/Hooky/E2ESpec.hs
@@ -13,7 +13,7 @@ import Hooky.TestUtils.Git (withGitRepo)
 import Hooky.TestUtils.Hooky (HookyExe (..))
 import Skeletest
 import Skeletest.Predicate qualified as P
-import System.Directory (renameFile)
+import System.Directory (removeFile, renameFile)
 import System.Exit (ExitCode (..))
 import System.IO qualified as IO
 import System.Process qualified as Process
@@ -58,6 +58,14 @@ spec = do
       (code, _, stderr) <- readHooky ["run", "--all", "file.txt"]
       code `shouldBe` ExitFailure 1
       stderr `shouldBe` "Expected exactly one of: FILES, --modified, --staged, --all, --prev\n"
+
+    it "filters out deleted files" $ do
+      withGitRepo $ \git -> do
+        writeFile ".hooky.kdl" hookyConfigEofFixer
+        writeFile "bad.txt" "bad"
+        git.exec ["add", ".hooky.kdl", "bad.txt"] >> git.exec ["commit", "-m", "test"]
+        removeFile "bad.txt"
+        runHooky ["run", "--all"] `shouldSatisfy` P.returns (P.eq ExitSuccess)
 
     it "stashes intent-to-add files" $ do
       withGitRepo $ \git -> do


### PR DESCRIPTION
Currently, `hooky` will pass deleted files to hooks:
```
╭─── FAIL hooky (duration: 0.050297s)
│ ═══▶ Running: hooky lint
│ src/Hooky/Run.hs: pathIsSymbolicLink:getSymbolicLinkStatus: does not exist (No such file or directory)
◈
╭─── FAIL fourmolu (duration: 0.061118s)
│ ═══▶ Running: tools/fourmolu -m check
│ Loaded config from: /Users/bchinn/repos/hooky/fourmolu.yaml
│ fourmolu: src/Hooky/Run.hs: withBinaryFile: does not exist (No such file or directory)
│ HasCallStack backtrace:
│   collectBacktraces, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:92:13 in ghc-internal:GHC.Internal.Exception
│   toExceptionWithBacktrace, called at libraries/ghc-internal/src/GHC/Internal/IO.hs:260:11 in ghc-internal:GHC.Internal.IO
│   throwIO, called at src/UnliftIO/Internals/Async.hs:810:24 in unliftio-0.2.25.0-I9fws71W6tYJAEbry1byak:UnliftIO.Internals.Async
│
│
◈
2 hooks failed ✘
```